### PR TITLE
Enhancement to reduce task running time

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,17 @@ depending on how the autoscaling is configured.
 
 While manually scaling the cluster down is possible, it's certainly a pain. Obviously the solution is
 to automate the process. This solution will perform the following steps to scale down an ECS cluster:
-* get a list of the instances in the given cluster, and order them by load (number of tasks)
+* check for any instances in a DRAINING state and attempt to remove them from the cluster (see below)
+* get a list of the ACTIVE instances in the given cluster, and order them by load (number of tasks)
 * put X number of instances into a DRAINING state
-* wait for the instances to be ready to terminate
-* terminate the instances and decrement the desired count in the autoscaling group
+* attempt to remove them from the cluster (see below)
+
+Note: When attempting to remove instances from the cluster, the following conditions need to be met:
+* no running tasks on the instance OR
+* only tasks matching the ignore list running on the instance
+
+If the above conditions are met, then the following happens:
+* terminate the instance(s) and decrement the desired count in the autoscaling group
  
 Alternatively, an instance ID can be specified to be selectively removed from the cluster. Note that this
 instance MUST be in a DRAINING state already.
@@ -24,6 +31,11 @@ instance MUST be in a DRAINING state already.
 
 # Usage
 
+This tool was developed with the idea of it being run periodically (as an ECS scheduled task, although 
+generally speaking, a simple cron job would also work) - that way if an instance wasn't able to be
+immediately removed from the cluster (due to running tasks on that instance), the instance would get
+removed in a subsequent run of the tool.
+
 The easiest way to run the tool is from docker (because docker rocks).
 You will need to pass in variables specific to the ECS task you want to affect
 
@@ -32,7 +44,7 @@ usage: ecs_cluster_scaledown.py [-h] [--aws-access-key-id AWS_ACCESS_KEY]
                                 [--aws-secret-access-key AWS_SECRET_KEY]
                                 --cluster-name CLUSTER_NAME [--count COUNT]
                                 [--instance-ids INSTANCE_IDS [INSTANCE_IDS ...]]
-                                [--max-wait MAX_WAIT]
+                                [--ignore-list IGNORE_LIST [IGNORE_LIST ...]]
                                 [--alarm-name ALARM_NAME] --region REGION
                                 [--profile PROFILE] [--verbose] [--dryrun]
 
@@ -49,7 +61,8 @@ optional arguments:
   --count COUNT         Number of instances to remove [1]
   --instance-ids INSTANCE_IDS [INSTANCE_IDS ...]
                         Instance ID(s) to be removed
-  --max-wait MAX_WAIT   Maximum wait time (hours) [unlimited]
+  --ignore-list IGNORE_LIST [IGNORE_LIST ...]
+                        Tasks to be ignored when determining running tasks
   --alarm-name ALARM_NAME
                         Alarm name to check if scale down should be attempted
   --region REGION       The AWS region the cluster is in
@@ -69,7 +82,6 @@ docker run \
    signiant/ecs-cluster-scaledown \
        --cluster-name test-cluster \
        --count 2 \
-       --max-wait 48
        --region us-east-1 \
        --dryrun
 ```
@@ -78,13 +90,10 @@ In this example, the arguments after the image name are
 
 * --cluster-name <ECS cluster name>
 * --count <Number of instances to scale down by>
-* --max-wait <max wait time until forcing termination in hours>
 * --region <AWS region>
 * --dryrun (don't actually scale down - display only)
 
-In the above example, we tell the task to scale down the cluster by 2 instances. If the currently
-running tasks on whatever instances are selected (the least loaded at the time this task is started)
-are not done executing after 48 hours, the instances will be terminated regardless. Note that no AWS
+In the above example, we tell the task to scale down the cluster by 2 instances. Note that no AWS
 access key or secret access key, or even an AWS profile are provided - in this case the task was run
 as a scheduled task in an ECS cluster using an IAM Role, hence they weren't needed.
 
@@ -103,22 +112,45 @@ docker run \
 In the above example, we tell the task to scale down the cluster by 1 instance (no --count argument was
 given, so it uses the default of 1). The first thing the task will do is check the StateValue of the given
 alarm to make sure it is in 'ALARM' state before proceeding - if it isn't, the task exits immediately.
-No max-wait argument is given, so this task will wait indefinitely for tasks on the selected instance to
-finish before terminating that instance.
 
 ```bash
 docker run \
-  -e AWS_ACCESS_KEY_ID=XXXXXX \
-  -e AWS_SECRET_ACCESS_KEY=XXXXX \
+  signiant/ecs-cluster-scaledown \
+        --cluster-name test-cluster \
+        --region us-east-1 \
+        --ignore-list LogspoutTask
+```
+
+In the above example, we tell the task to scale down the cluster by 1 instance (no --count argument was
+given, so it uses the default of 1). In this case no alarm is given, so a cluster scale down will be 
+always be attempted. (Note that the autoscaling group associated with this cluster is always queried for
+the minimum size and a scale down will only be attempted provided it will not result in the cluster size
+falling below the minimum) In this case an ignore list is also provided - any tasks matching items in the
+given ignore list will be ignored when checking instances for running tasks.
+
+```bash
+docker run \
   signiant/ecs-cluster-scaledown \
         --cluster-name test-cluster \
         --region us-east-1 \
         --instance-ids i-0x1x2x3x4x5x6x7x8 i-0x2x3x4x5x6x7x8x9 i-3x4x5x6x7x8x9x0x1
 ```
 
-In the above example, we tell the task to scale down the cluster by the given instances. Since no max-wait
-argument is given, the task will wait indefinitely for tasks to finish before terminating the instance. Note
-that instances will be removed in the order they are listed.
+In the above example, we tell the task to scale down the cluster by the given instances. Note that 
+instances will be removed in the order they are listed.
+
+NOTE: To clear out any instances in a DRAINING state *without* scaling down the cluster, provide a count
+of 0, eg:
+
+```bash
+docker run \
+  signiant/ecs-cluster-scaledown \
+        --cluster-name test-cluster \
+        --region us-east-1 \
+        --ignore-list LogspoutTask
+        -- count 0
+```
+
 
 # Warnings / Known Issues
 


### PR DESCRIPTION
Check for instances in DRAINING state and terminate if possible.
Don't leave task running while waiting for tasks to end - termination will happen on subsequent runs